### PR TITLE
Adds documentation for Stronghold (Off the Charts)

### DIFF
--- a/endpoints/openapi.json
+++ b/endpoints/openapi.json
@@ -2253,6 +2253,56 @@
         }
       },
     },
+    "/api/v1/payment-types": {
+      "get": {
+        "description": "Retrieve all payment types for an organization.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List payment types response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentType"
+                },
+                "example": {
+                  "data": [
+                    {
+                      "id": 88,
+                      "name": "Cash",
+                      "fee": 0,
+                      "feeDescription": null,
+                      "method": "cash",
+                      "feePercent": "0",
+                      "createdAt": "2025-04-11T20:34:08.842Z"
+                    },
+                    {
+                      "id": 90,
+                      "name": "Debit Card",
+                      "fee": 100,
+                      "feeDescription": "Debit Card Fee",
+                      "method": "debit",
+                      "feePercent": "3.5",
+                      "createdAt": "2025-05-08T22:42:31.092Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError"
+                }
+              }
+            }
+          }
+        }
+      },
+    },
     "/api/v1/instore-queues": {
       "get": {
         "description": "Retrieve waiting room information for the dispensary.",
@@ -6008,6 +6058,41 @@
                 "description": "The last name of the employee"
               }
             }
+          }
+        }
+      },
+      "PaymentType": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "description": "The id for the payment type"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the payment type"
+          },
+          "fee": {
+            "type": "number",
+            "description": "The flat fee for using this payment type in cents"
+          },
+          "feeDescription": {
+            "type": "string",
+            "description": "The description for the fee to show to the customer",
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
+            "description": "The medium the payment type uses to collect money",
+            "enum": ["cash", "debit", "other", "stronghold"]
+          },
+          "feePercent": {
+            "type": "string",
+            "description": "The percentage fee for this payment type"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date this payment type was created"
           }
         }
       },

--- a/endpoints/openapi.json
+++ b/endpoints/openapi.json
@@ -2253,6 +2253,109 @@
         }
       },
     },
+    "/api/v1/payment-intents": {
+      "post": {
+        "description": "Create a payment intent for an order payment",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["orderPaymentId", "source"],
+                "properties": {
+                  "orderPaymentId": {
+                    "type": "number",
+                    "description": "The ID of the order payment to create this intent for"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "Submit `e-commerce` if this is an online order or `retail` if it is taking place in a store.",
+                    "enum": ["e-commerce", "retail"]
+                  }
+                }
+              },
+              "example": {
+                "orderPaymentId": 90,
+                "source": "e-commerce"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Create payment intent response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                      "description": "The ID for the payment intent"
+                    },
+                    "organizationId": {
+                      "type": "number",
+                      "description": "The organization ID for this payment intent"
+                    },
+                    "userId": {
+                      "type": "number",
+                      "description": "The ID of the user this payment intent was created for"
+                    },
+                    "paymentIntentId": {
+                      "type": "number",
+                      "description": "The ID of the payment type for this intent"
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "The amount of the payment intent before fees in cents"
+                    },
+                    "feeAmount": {
+                      "type": "number",
+                      "description": "The amount of the fee in cents"
+                    },
+                    "strongholdId": {
+                      "type": "string",
+                      "description": "The ID of the payment object in Stronghold's system"
+                    },
+                    "strongholdLink": {
+                      "type": "string",
+                      "description": "The payment link that should be shown to the customer to complete the payment"
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "id": 39,
+                    "organizationId": 1,
+                    "userId": 18275,
+                    "paymentTypeId": 90,
+                    "status": "created",
+                    "type": "stronghold",
+                    "source": "e-commerce",
+                    "amount": 3400,
+                    "feeAmount": 119,
+                    "strongholdId": "EWQ3DeP8",
+                    "strongholdLink": "https://sandbox.strongholdpay.com/l/EWQ3DeP8",
+                    "updatedAt": "2025-05-09T21:25:17.153Z",
+                    "createdAt": "2025-05-09T21:25:17.153Z"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/payment-types": {
       "get": {
         "description": "Retrieve all payment types for an organization.",
@@ -6083,7 +6186,7 @@
           },
           "method": {
             "type": "string",
-            "description": "The medium the payment type uses to collect money",
+            "description": "The medium the payment type uses to collect payment",
             "enum": ["cash", "debit", "other", "stronghold"]
           },
           "feePercent": {

--- a/endpoints/orders/create-payment-intent.mdx
+++ b/endpoints/orders/create-payment-intent.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Create a payment intent'
+openapi: 'POST /api/v1/payment-intents'
+---

--- a/endpoints/orders/list-payment-types.mdx
+++ b/endpoints/orders/list-payment-types.mdx
@@ -1,0 +1,4 @@
+---
+title: 'List payment types'
+openapi: 'GET /api/v1/payment-types'
+---

--- a/guides/stronghold.mdx
+++ b/guides/stronghold.mdx
@@ -1,0 +1,42 @@
+---
+title: Stronghold Payments
+description: How to integration with Stronghold via Meadow
+---
+
+# Step 1 - Retrieve payment types
+
+Fetch all the payment types for an organization using [GET /api/v1/payment-types](/endpoints/orders/list-payment-types)
+
+# Step 2 - Create a payment with the order
+
+When retrieving pricing ([POST /api/v1/orders/pricing](/endpoints/orders/retrieve-pricing)) and creating an order ([POST /api/v1/orders](/endpoints/orders/create-order)), you will need to create a payment to be associated with that order using a Stronghold payment type. To do this, please submit a `payments[]` array alongside the rest of your request body like so:
+
+```
+{
+  "lineItems": [
+    {
+      "productOptionId": 1337,
+      "quantity": 2
+    }
+  ],
+  ...REST_OF_ORDER_PROPERTIES,
+  "payments": [
+    {
+      "paymentTypeId": 123,
+      "remaining": true
+    }
+  ]
+}
+```
+
+The value used for `paymentTypeId` needs to come from one of the payment methods fetched in Step 1. Please submit `"remaining": true` along with it to signal this payment is for the remaining amount of the order.
+
+# Step 3 - Create the Stronghold payment intent
+
+Create a Stronghold payment intent using [POST /api/v1/payment-intents](/endpoints/orders/create-payment-intent). You must retrieve the `orderPaymentId` to submit using the response from creating an order. You will find this ID in `data.payments[0].id`.
+
+# Step 4 - Show customer the Stronghold link
+
+After you create the payment intent, you will receive a `strongholdLink` as part of the response. This is a webpage where the customer can complete their payment. You may either redirect the customer to this page, or show them a button that when clicked will take them to this page.
+
+The rest of the Stronghold payment flow will be able to be completed in the Meadow backend.

--- a/mint.json
+++ b/mint.json
@@ -56,7 +56,8 @@
         "endpoints/orders/customer-matching",
         "endpoints/orders/retrieve-status",
         "endpoints/orders/retrieve-pricing",
-        "endpoints/orders/create-order"
+        "endpoints/orders/create-order",
+        "endpoints/orders/list-payment-types"
       ]
     },
     {


### PR DESCRIPTION
Only making the payment types endpoint public accessible. The other guide will only be accessible via direct navigation to the URL so that we can keep it "private"